### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [ main ]
 
+permissions:
+  contents: read
+
 jobs:
   ci:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/cte-zl-ifrn/moodle-local_suap/security/code-scanning/1](https://github.com/cte-zl-ifrn/moodle-local_suap/security/code-scanning/1)

Add an explicit `permissions` block to the workflow so the token is minimally scoped.  
Best fix without changing functionality: define workflow-level permissions right after the `on:` section (before `jobs:`), with:

- `contents: read`

This preserves current behavior (checkout and CI reads) while documenting and enforcing least privilege for all jobs in this workflow.

File to edit: `.github/workflows/ci.yml`  
Region: after line 7 (`pull_request` branch config) and before line 9 (`jobs:`).  
No new imports, methods, or dependencies are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
